### PR TITLE
Base setup for integration tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,4 +40,4 @@ jobs:
         run: CGO_ENABLED=0 GOOS=linux go build -o ./opsrelay
 
       - name: Test
-        run: GODEBUG=cgocheck=0 go test --timeout 15m -cover -short -coverprofile=cover.out -covermode=atomic ./...
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,9 @@
+TESTALL = $$(go list ./...)
+TESTE2E = ./tests/...
+GOTEST = GODEBUG=cgocheck=0 go test --count=1
+
+test:
+	$(GOTEST) --timeout 5m $(TESTALL)
+
+test-integration:
+	$(GOTEST) --timeout 5m $(TESTE2E)

--- a/config/config.go
+++ b/config/config.go
@@ -29,24 +29,30 @@ type configJson struct {
 	} `json:"relay"`
 }
 
+type Network struct {
+	RpcUrl string `json:"rpc_url"`
+}
+
+type Contracts struct {
+	Atlas             common.Address `json:"atlas"`
+	AtlasVerification common.Address `json:"atlasVerification"`
+	Simulator         common.Address `json:"simulator"`
+}
+
+type Gas struct {
+	MaxPerUserOperation   *big.Int `json:"max_per_user_operation"`
+	MaxPerSolverOperation *big.Int `json:"max_per_solver_operation"`
+	MaxPerDAppOperation   *big.Int `json:"max_per_dApp_operation"`
+}
+
+type Relay struct {
+	Gas Gas `json:"gas"`
+}
+
 type Config struct {
-	Network struct {
-		RpcUrl string `json:"rpc_url"`
-	} `json:"network"`
-
-	Contracts struct {
-		Atlas             common.Address `json:"atlas"`
-		AtlasVerification common.Address `json:"atlasVerification"`
-		Simulator         common.Address `json:"simulator"`
-	} `json:"contracts"`
-
-	Relay struct {
-		Gas struct {
-			MaxPerUserOperation   *big.Int `json:"max_per_user_operation"`
-			MaxPerSolverOperation *big.Int `json:"max_per_solver_operation"`
-			MaxPerDAppOperation   *big.Int `json:"max_per_dApp_operation"`
-		} `json:"gas"`
-	} `json:"relay"`
+	Network   Network
+	Contracts Contracts
+	Relay     Relay
 }
 
 func Load() *Config {

--- a/core/init.go
+++ b/core/init.go
@@ -1,0 +1,23 @@
+package core
+
+import (
+	"github.com/FastLane-Labs/atlas-operations-relay/config"
+	"github.com/FastLane-Labs/atlas-operations-relay/log"
+	"github.com/ethereum/go-ethereum/ethclient"
+)
+
+func StartRelay(conf *config.Config, serverReadyChan chan struct{}) {
+	log.InitLogger()
+
+	if conf == nil {
+		conf = config.Load()
+	}
+
+	ethClient, err := ethclient.Dial(conf.Network.RpcUrl)
+	if err != nil {
+		log.Error("failed to connect to the Ethereum client", "err", err)
+		return
+	}
+
+	NewRelay(ethClient, conf).Run(serverReadyChan)
+}

--- a/core/relay.go
+++ b/core/relay.go
@@ -77,8 +77,8 @@ func NewRelay(ethClient *ethclient.Client, config *config.Config) *Relay {
 	return relay
 }
 
-func (r *Relay) Run() {
-	r.server.ListenAndServe()
+func (r *Relay) Run(serverReadyChan chan struct{}) {
+	r.server.ListenAndServe(serverReadyChan)
 }
 
 func (r *Relay) submitUserOperation(userOp *operation.UserOperation) (common.Hash, *relayerror.Error) {

--- a/core/server.go
+++ b/core/server.go
@@ -3,6 +3,7 @@ package core
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"sync"
 	"time"
@@ -231,9 +232,19 @@ func NewServer(router *mux.Router, newSolverOperation newSolverOperationFn, getD
 	}
 }
 
-func (s *Server) ListenAndServe() {
+func (s *Server) ListenAndServe(serverReadyChan chan struct{}) {
+	httpServer := &http.Server{Addr: ":8080", Handler: s.router}
+	ln, err := net.Listen("tcp", httpServer.Addr)
+	if err != nil {
+		panic(err)
+	}
+
 	log.Info("server started")
-	err := http.ListenAndServe(":8080", s.router)
+	if serverReadyChan != nil {
+		close(serverReadyChan)
+	}
+
+	err = httpServer.Serve(ln)
 	log.Info("server stopped", "err", err)
 }
 

--- a/main.go
+++ b/main.go
@@ -1,21 +1,9 @@
 package main
 
 import (
-	"github.com/FastLane-Labs/atlas-operations-relay/config"
 	"github.com/FastLane-Labs/atlas-operations-relay/core"
-	"github.com/FastLane-Labs/atlas-operations-relay/log"
-	"github.com/ethereum/go-ethereum/ethclient"
 )
 
 func main() {
-	log.InitLogger()
-	config := config.Load()
-
-	ethClient, err := ethclient.Dial(config.Network.RpcUrl)
-	if err != nil {
-		log.Error("failed to connect to the Ethereum client", "err", err)
-		return
-	}
-
-	core.NewRelay(ethClient, config).Run()
+	core.StartRelay(nil, nil)
 }

--- a/tests/example_test.go
+++ b/tests/example_test.go
@@ -1,0 +1,9 @@
+package tests
+
+import (
+	"testing"
+)
+
+func TestExample(t *testing.T) {
+	t.Log("Test passed")
+}

--- a/tests/init_test.go
+++ b/tests/init_test.go
@@ -1,0 +1,32 @@
+package tests
+
+import (
+	"os"
+	"testing"
+
+	"github.com/FastLane-Labs/atlas-operations-relay/config"
+	"github.com/FastLane-Labs/atlas-operations-relay/core"
+	"github.com/ethereum/go-ethereum/common"
+)
+
+var (
+	conf = &config.Config{
+		Network: config.Network{
+			RpcUrl: "https://rpc.sepolia.org/",
+		},
+		Contracts: config.Contracts{
+			Atlas:             common.HexToAddress("0x090A1134ebF3066f87dB165a910E832a87C2Ffb5"),
+			AtlasVerification: common.HexToAddress("0x15261B0437b0e54d6f0Dd308148a359Bb0191A81"),
+			Simulator:         common.HexToAddress("0x8F4C1158fA69f973973b6ba7A1b3F58EE9204d1A"),
+		},
+	}
+)
+
+func TestMain(m *testing.M) {
+	serverReadyChan := make(chan struct{})
+	// Start the relay
+	go core.StartRelay(conf, serverReadyChan)
+	// Wait for the server to be ready
+	<-serverReadyChan
+	os.Exit(m.Run())
+}


### PR DESCRIPTION
Base setup for integration tests.

Tests would be contained in the `tests` folder.
`init_test.go` takes care of launching the relay for all other tests, and config can be setup there, without touching `config.json` at the repo's root.

We can also run all unit + integration tests with a single command: `make test`
or only integration tests with: `make test-integration`