### PR TITLE
docker-publish an image on a new release event

### DIFF
--- a/.github/docker-publish.yml
+++ b/.github/docker-publish.yml
@@ -1,0 +1,31 @@
+name: Docker Image CI
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    
+    steps:
+    - name: Check out the code
+      uses: actions/checkout@v2
+      
+    - name: Log in to Docker Hub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        
+    - name: Build and push Docker image
+      uses: docker/build-push-action@v2
+      with:
+        context: .
+        file: ./Dockerfile
+        push: true
+        tags: |
+          fastlanelabs/ops-relay:${{ github.event.release.tag_name }}
+          fastlanelabs/ops-relay:latest
+        build-args: |
+          VERSION=${{ github.event.release.tag_name }}

--- a/.github/docker-publish.yml
+++ b/.github/docker-publish.yml
@@ -27,5 +27,3 @@ jobs:
         tags: |
           fastlanelabs/ops-relay:${{ github.event.release.tag_name }}
           fastlanelabs/ops-relay:latest
-        build-args: |
-          VERSION=${{ github.event.release.tag_name }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,7 @@ COPY ./go.mod ./go.sum ./
 RUN go mod download
 COPY . ./
 
-ARG VERSION=""
-RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X main.Version=${VERSION}" -o /opsrelay
+RUN CGO_ENABLED=0 GOOS=linux go build -o /opsrelay
 
 EXPOSE 8080
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,9 @@ RUN apt-get update
 COPY ./go.mod ./go.sum ./
 RUN go mod download
 COPY . ./
-RUN CGO_ENABLED=0 GOOS=linux go build -o /opsrelay
+
+ARG VERSION=""
+RUN CGO_ENABLED=0 GOOS=linux go build -ldflags "-X main.Version=${VERSION}" -o /opsrelay
 
 EXPOSE 8080
 

--- a/main.go
+++ b/main.go
@@ -1,9 +1,24 @@
 package main
 
 import (
+	"fmt"
+	"os"
+
 	"github.com/FastLane-Labs/atlas-operations-relay/core"
 )
 
+var (
+	Version = ""
+)
+
 func main() {
+	if len(os.Args) > 1 && os.Args[1] == "version" {
+		if Version == ""{
+			os.Exit(0)
+		}
+		fmt.Printf("Version: %s\n", Version)
+		os.Exit(0)
+	}
+
 	core.StartRelay(nil, nil)
 }

--- a/main.go
+++ b/main.go
@@ -1,24 +1,7 @@
 package main
 
-import (
-	"fmt"
-	"os"
-
-	"github.com/FastLane-Labs/atlas-operations-relay/core"
-)
-
-var (
-	Version = ""
-)
+import "github.com/FastLane-Labs/atlas-operations-relay/core"
 
 func main() {
-	if len(os.Args) > 1 && os.Args[1] == "version" {
-		if Version == ""{
-			os.Exit(0)
-		}
-		fmt.Printf("Version: %s\n", Version)
-		os.Exit(0)
-	}
-
 	core.StartRelay(nil, nil)
 }


### PR DESCRIPTION
1. Added a docker-publish workflow.
2. Added support for printing the version of ops-relay. Right now it is configured to get the info within the context of the docker container. For `./ops-relay version` to work, the version information has to be injected into the binary. Not sure if this is ideal. 
@jj1980a 