### PR TITLE
Priority queue by reputation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,11 @@ If a combination is used, the priority order is **ENV var** > **CLI param** > **
     - *CLI flag*:     `--relay.auction.duration`
     - *default*:      `500`
     - *comment*:      in milliseconds, values <= 0 are ignored
+- **MAX SOLUTIONS PER AUCTION**
+    - *config.json*:  `relay.auction.max_solutions` (integer)
+    - *CLI flag*:     `--relay.auction.max_solutions`
+    - *default*:      `10`
+    - *comment*:      values <= 0 are ignored
 - **MAX GAS PER USER OPERATION** (optional)
     - *config.json*:  `relay.gas.max_per_user_operation` (integer)
     - *CLI flag*:     `--relay.gas.max_per_user_operation`

--- a/auction/auction.go
+++ b/auction/auction.go
@@ -14,6 +14,7 @@ var (
 	ErrAuctionClosed              = relayerror.NewError(4100, "auction for this user operation has already ended")
 	ErrAuctionOngoing             = relayerror.NewError(4101, "auction for this user operation is ongoing")
 	ErrSolverAlreadyParticipating = relayerror.NewError(4102, "solver is already participating in this auction")
+	ErrSolverOperationNotFound    = relayerror.NewError(4103, "solver operation not found")
 )
 
 type Auction struct {
@@ -23,10 +24,14 @@ type Auction struct {
 	userOp                  *operation.UserOperation
 	userOperationPartialRaw *operation.UserOperationPartialRaw
 	solverOpsWithScore      []*operation.SolverOperationWithScore
+	solverOpsStatus         map[common.Hash]*SolverStatus
 	solversParticipating    map[common.Address]struct{}
 	solverGasLimit          uint32
 
-	completionSubs []chan []*operation.SolverOperationWithScore
+	solverOpsCompletionSubs []chan []*operation.SolverOperationWithScore
+
+	// Indexed by solverOpHash
+	solverStatusesCompletionSubs map[common.Hash][]chan *SolverStatus
 
 	createdAt time.Time
 
@@ -35,15 +40,17 @@ type Auction struct {
 
 func NewAuction(duration time.Duration, userOp *operation.UserOperation, userOperationPartialRaw *operation.UserOperationPartialRaw, userOpHash common.Hash, solverGasLimit uint32) *Auction {
 	auction := &Auction{
-		open:                    true,
-		userOpHash:              userOpHash,
-		userOp:                  userOp,
-		userOperationPartialRaw: userOperationPartialRaw,
-		solverOpsWithScore:      make([]*operation.SolverOperationWithScore, 0),
-		solversParticipating:    make(map[common.Address]struct{}),
-		solverGasLimit:          solverGasLimit,
-		completionSubs:          make([]chan []*operation.SolverOperationWithScore, 0),
-		createdAt:               time.Now(),
+		open:                         true,
+		userOpHash:                   userOpHash,
+		userOp:                       userOp,
+		userOperationPartialRaw:      userOperationPartialRaw,
+		solverOpsWithScore:           make([]*operation.SolverOperationWithScore, 0),
+		solverOpsStatus:              make(map[common.Hash]*SolverStatus),
+		solversParticipating:         make(map[common.Address]struct{}),
+		solverGasLimit:               solverGasLimit,
+		solverOpsCompletionSubs:      make([]chan []*operation.SolverOperationWithScore, 0),
+		solverStatusesCompletionSubs: make(map[common.Hash][]chan *SolverStatus),
+		createdAt:                    time.Now(),
 	}
 
 	time.AfterFunc(duration, auction.close)
@@ -51,61 +58,101 @@ func NewAuction(duration time.Duration, userOp *operation.UserOperation, userOpe
 }
 
 func (a *Auction) close() {
-	a.mu.Lock()
-	defer a.mu.Unlock()
+	a.mu.RLock()
+	defer a.mu.RUnlock()
 
 	log.Info("closing auction", "userOpHash", a.userOpHash.Hex())
 	a.open = false
 
-	for _, subChan := range a.completionSubs {
+	for _, subChan := range a.solverOpsCompletionSubs {
 		select {
 		case subChan <- a.solverOpsWithScore:
 		default:
 			// Sub isn't listening, don't block
 		}
 	}
+
+	for solverOpHash, subs := range a.solverStatusesCompletionSubs {
+		status := a.solverOpsStatus[solverOpHash]
+		for _, subChan := range subs {
+			select {
+			case subChan <- status:
+			default:
+				// Sub isn't listening, don't block
+			}
+		}
+	}
 }
 
-func (a *Auction) addCompletionSub(subChan chan []*operation.SolverOperationWithScore) {
-	a.mu.Lock()
-	defer a.mu.Unlock()
-
-	a.completionSubs = append(a.completionSubs, subChan)
+func (a *Auction) addSolverOpsCompletionSub(subChan chan []*operation.SolverOperationWithScore) {
+	a.solverOpsCompletionSubs = append(a.solverOpsCompletionSubs, subChan)
 }
 
-func (a *Auction) addSolverOp(solverOp *operation.SolverOperationWithScore) *relayerror.Error {
+func (a *Auction) addSolverStatusesCompletionSub(solverOpHash common.Hash, subChan chan *SolverStatus) {
+	if _, ok := a.solverStatusesCompletionSubs[solverOpHash]; !ok {
+		a.solverStatusesCompletionSubs[solverOpHash] = make([]chan *SolverStatus, 0)
+	}
+
+	a.solverStatusesCompletionSubs[solverOpHash] = append(a.solverStatusesCompletionSubs[solverOpHash], subChan)
+}
+
+func (a *Auction) addSolverOp(solverOp *operation.SolverOperationWithScore) (common.Hash, *relayerror.Error) {
 	a.mu.Lock()
 	defer a.mu.Unlock()
 
 	if !a.open {
 		log.Info("auction for this user operation has already ended", "userOpHash", a.userOpHash.Hex())
-		return ErrAuctionClosed
+		return common.Hash{}, ErrAuctionClosed
 	}
 
 	if _, alreadyParticipating := a.solversParticipating[solverOp.SolverOperation.From]; alreadyParticipating {
 		log.Info("solver is already participating in this auction", "userOpHash", a.userOpHash.Hex(), "solver", solverOp.SolverOperation.From.Hex())
-		return ErrSolverAlreadyParticipating
+		return common.Hash{}, ErrSolverAlreadyParticipating
+	}
+
+	solverOpHash, relayErr := solverOp.SolverOperation.Hash()
+	if relayErr != nil {
+		return common.Hash{}, relayErr
 	}
 
 	a.solverOpsWithScore = append(a.solverOpsWithScore, solverOp)
+	a.solverOpsStatus[solverOpHash] = SolverStatusAuctionPending
 	a.solversParticipating[solverOp.SolverOperation.From] = struct{}{}
-	return nil
+
+	return solverOpHash, nil
 }
 
 func (a *Auction) getSolverOps(completionChan chan []*operation.SolverOperationWithScore) ([]*operation.SolverOperationWithScore, *relayerror.Error) {
-	a.mu.RLock()
-	open := a.open
-	a.mu.RUnlock()
+	a.mu.Lock()
+	defer a.mu.Unlock()
 
-	if completionChan != nil && open {
-		a.addCompletionSub(completionChan)
+	if completionChan != nil && a.open {
+		a.addSolverOpsCompletionSub(completionChan)
 		return nil, nil
 	}
 
-	if open {
+	if a.open {
 		log.Info("auction for this user operation is ongoing", "userOpHash", a.userOpHash.Hex())
 		return nil, ErrAuctionOngoing
 	}
 
 	return a.solverOpsWithScore, nil
+}
+
+func (a *Auction) getSolverOpStatus(solverOpHash common.Hash, completionChan chan *SolverStatus) (*SolverStatus, *relayerror.Error) {
+	a.mu.Lock()
+	defer a.mu.Unlock()
+
+	status, ok := a.solverOpsStatus[solverOpHash]
+	if !ok {
+		log.Info("solver operation not found in this auction", "solverOpHash", solverOpHash.Hex(), "userOpHash", a.userOpHash.Hex())
+		return nil, ErrSolverOperationNotFound
+	}
+
+	if completionChan != nil && a.open {
+		a.addSolverStatusesCompletionSub(solverOpHash, completionChan)
+		return nil, nil
+	}
+
+	return status, nil
 }

--- a/auction/solver.go
+++ b/auction/solver.go
@@ -1,0 +1,26 @@
+package auction
+
+const (
+	SolverStatusCodeFailure = iota
+	SolverStatusCodeSuccess
+	SolverStatusCodePending
+)
+
+var (
+	SolverStatusIncluded         = NewSolverStatus(SolverStatusCodeSuccess, "included in auction")
+	SolverStatusAuctionPending   = NewSolverStatus(SolverStatusCodePending, "auction is pending")
+	SolverStatusFailedSimulation = NewSolverStatus(SolverStatusCodeFailure, "failed simulation")
+	SolverStatusNotIncluded      = NewSolverStatus(SolverStatusCodeFailure, "not included in auction")
+)
+
+type SolverStatus struct {
+	Code    int    `json:"code"`
+	Message string `json:"message"`
+}
+
+func NewSolverStatus(code int, message string) *SolverStatus {
+	return &SolverStatus{
+		Code:    code,
+		Message: message,
+	}
+}

--- a/config.json
+++ b/config.json
@@ -9,7 +9,8 @@
   },
   "relay": {
     "auction": {
-      "duration": 0
+      "duration": 0,
+      "max_solutions": 0
     },
     "gas": {
       "max_per_user_operation": 0,

--- a/core/relay.go
+++ b/core/relay.go
@@ -14,8 +14,7 @@ import (
 )
 
 const (
-	SolverOpSuccessfullySubmitted = "solver operation successfully submitted"
-	BundleSuccessfullySubmitted   = "bundle successfully submitted"
+	BundleSuccessfullySubmitted = "bundle successfully submitted"
 )
 
 var (
@@ -69,7 +68,7 @@ func NewRelay(ethClient *ethclient.Client, config *config.Config) *Relay {
 
 	r.auctionManager = auction.NewManager(ethClient, config, atlasDomainSeparator, r.solverGasLimit, r.balanceOfBonded, r.reputationScore)
 	r.bundleManager = bundle.NewManager(ethClient, config, atlasDomainSeparator)
-	r.server = NewServer(NewRouter(NewApi(r)), r.auctionManager.NewSolverOperation, r.getDAppSignatories)
+	r.server = NewServer(NewRouter(NewApi(r)), r.auctionManager.NewSolverOperation, r.auctionManager.GetSolverOperationStatus, r.getDAppSignatories)
 
 	return r
 }
@@ -111,13 +110,10 @@ func (r *Relay) getBundleHash(userOpHash common.Hash, completionChan chan *bundl
 	return r.bundleManager.GetBundleHash(userOpHash, completionChan)
 }
 
-func (r *Relay) submitSolverOperation(solverOp *operation.SolverOperation) (string, *relayerror.Error) {
-	var result string
+func (r *Relay) submitSolverOperation(solverOp *operation.SolverOperation) (common.Hash, *relayerror.Error) {
+	return r.auctionManager.NewSolverOperation(solverOp)
+}
 
-	relayErr := r.auctionManager.NewSolverOperation(solverOp)
-	if relayErr == nil {
-		result = SolverOpSuccessfullySubmitted
-	}
-
-	return result, relayErr
+func (r *Relay) getSolverOperationStatus(solverOpHash common.Hash, completionChan chan *auction.SolverStatus) (*auction.SolverStatus, *relayerror.Error) {
+	return r.auctionManager.GetSolverOperationStatus(solverOpHash, completionChan)
 }

--- a/core/router.go
+++ b/core/router.go
@@ -80,6 +80,12 @@ func buildRoutes(api *Api) []Route {
 			api.SubmitSolverOperation,
 		},
 		{
+			"GetSolverOperationStatus",
+			http.MethodGet,
+			"/solverOperationStatus",
+			api.GetSolverOperationStatus,
+		},
+		{
 			"WebsocketSolver",
 			http.MethodGet,
 			"/ws/solver",

--- a/core/server.go
+++ b/core/server.go
@@ -98,7 +98,7 @@ var (
 )
 
 type newSolverOperationFn func(*operation.SolverOperation) (common.Hash, *relayerror.Error)
-type getSolverOperationStatusFn func(solverOpHash common.Hash, completionChan chan *auction.SolverStatus) (*auction.SolverStatus, *relayerror.Error)
+type getSolverOperationStatusFn func(common.Hash, chan *auction.SolverStatus) (*auction.SolverStatus, *relayerror.Error)
 type getDAppSignatoriesFn func(common.Address) ([]common.Address, *relayerror.Error)
 type setAtlasTxHashFn func(common.Hash) *relayerror.Error
 type setRelayErrorFn func(*relayerror.Error) *relayerror.Error

--- a/operation/solver.go
+++ b/operation/solver.go
@@ -111,6 +111,7 @@ type SolverOperationWithScoreRaw struct {
 }
 
 type SolverOperationWithScore struct {
+	SolverOpHash    common.Hash
 	SolverOperation *SolverOperation
 	Score           int
 }

--- a/operation/solver.go
+++ b/operation/solver.go
@@ -20,6 +20,7 @@ var (
 	ErrSolverOpDAppControlMismatch = relayerror.NewError(2104, "solver operation's dApp control does not match the user operation's")
 	ErrSolverOpComputeProofHash    = relayerror.NewError(2105, "failed to compute solver proof hash")
 	ErrSolverOpSignatureInvalid    = relayerror.NewError(2106, "solver operation has invalid signature")
+	ErrSolverOpComputeHash         = relayerror.NewError(2107, "failed to compute solver operation hash")
 )
 
 var (
@@ -193,6 +194,14 @@ func (s *SolverOperation) Validate(userOperation *UserOperation, atlas common.Ad
 	}
 
 	return nil
+}
+
+func (s *SolverOperation) Hash() (common.Hash, *relayerror.Error) {
+	packed, err := s.AbiEncode()
+	if err != nil {
+		return common.Hash{}, ErrSolverOpComputeHash.AddError(err)
+	}
+	return crypto.Keccak256Hash(packed), nil
 }
 
 func (s *SolverOperation) AbiEncode() ([]byte, error) {

--- a/operation/solver_test.go
+++ b/operation/solver_test.go
@@ -25,6 +25,22 @@ func generateSolverOperation() *SolverOperation {
 	}
 }
 
+func TestSolverOperationHash(t *testing.T) {
+	t.Parallel()
+
+	solverOp := generateSolverOperation()
+	want := common.HexToHash("0xa56fe9ac02f8a4ae19dabe3d31635519cabd843a612210dd7711184e3fc943c3")
+
+	result, err := solverOp.Hash()
+	if err != nil {
+		t.Errorf("SolverOperation.Hash() error = %v", err)
+	}
+
+	if result != want {
+		t.Errorf("SolverOperation.Hash() = %v, want %v", result, want)
+	}
+}
+
 func TestSolverOperationAbiEncode(t *testing.T) {
 	t.Parallel()
 

--- a/specs/README.md
+++ b/specs/README.md
@@ -88,6 +88,7 @@ Note that all simulations referenced here can be easily done by calling view fun
 - 2104: solver operation's dApp control does not match the user operation's
 - 2105: failed to compute solver proof hash
 - 2106: solver operation has invalid signature
+- 2107: failed to compute solver operation hash
 
 **22xx** **(DApp operation error):**
 - 2200: dApp operation's 'from' field does not match user operation's session key

--- a/specs/README.md
+++ b/specs/README.md
@@ -108,7 +108,7 @@ Note that all simulations referenced here can be easily done by calling view fun
 - 3001: malformed json
 - 3002: invalid parameter
 - 3003: server corrupted data
-- 3004: invalid user operation hash
+- 3004: invalid operation hash
 - 3005: invalid bundler address
 - 3006: invalid timestamp
 - 3007: expired signature
@@ -139,6 +139,7 @@ Note that all simulations referenced here can be easily done by calling view fun
 - 4100: auction for this user operation has already ended
 - 4101: auction for this user operation is ongoing
 - 4102: solver is already participating in this auction
+- 4103: solver operation not found
 
 ### 5xxx (Bundle related error)
 

--- a/specs/rest-api.yaml
+++ b/specs/rest-api.yaml
@@ -95,7 +95,7 @@ paths:
       description: Get solver operations for a user operation previously submitted
       operationId: solverOperations
       parameters:
-        - name: userOpHash
+        - name: operationHash
           in: query
           description: The hash of the user operation
           required: true
@@ -185,7 +185,7 @@ paths:
       description: Get the Atlas transaction hash from a previously submitted bundle
       operationId: getBundleHash
       parameters:
-        - name: userOpHash
+        - name: operationHash
           in: query
           description: The hash of the user operation
           required: true
@@ -243,13 +243,13 @@ paths:
               $ref: '#/components/schemas/SolverOperation'
       responses:
         '200':
-          description: Solver operation successfully submitted and included in the auction
+          description: The hash of the solver operation
           content:
             application/json:
               schema:
                 type: string
-                description: Result message
-                examples: ["Solver operation successfully submitted"]
+                description: Solidity type bytes32
+                pattern: '^0x[0-9a-f]{64}$'
         '400':
           description: Invalid input
           content:
@@ -268,6 +268,58 @@ paths:
                 examples:
                   - code: 3001
                     message: server internal error
+
+  /solverOperationStatus:
+    get:
+      tags:
+        - solver
+      summary: Get a solver operation status, identified by its hash
+      description: Get solver operation status for an operation previously submitted
+      operationId: solverOperationStatus
+      parameters:
+        - name: operationHash
+          in: query
+          description: The hash of the solver operation
+          required: true
+          schema:
+            type: string
+            description: Solidity type bytes32
+            pattern: '^0x[0-9a-f]{64}$'
+        - name: wait
+          in: query
+          description: Hold the request until the end of the auction
+          required: false
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: Solver operation status successfully retrieved
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SolverOperationStatus'
+                examples:
+                  - code: 1
+                    message: included in auction
+        '400':
+          description: Invalid input
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+                examples:
+                  - code: 3004
+                    message: invalid operation hash
+        '500':
+          description: Relay exception
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
+                examples:
+                  - code: 3001
+                    message: server internal serror
 
 components:
   schemas:
@@ -470,6 +522,21 @@ components:
       xml:
         name: SolverOperationsWithScores
         wrapped: true
+    
+    SolverOperationStatus:
+      type: object
+      properties:
+        code:
+          type: integer
+          description: "The status code for the solver operation (0: failure, 1: success, 2: pending)"
+          enum: [0, 1, 2]
+        message:
+          type: string
+          description: The status message for the solver operation
+          examples: ["included in auction", "auction is pending"]
+      required:
+        - code
+        - message
 
     DAppOperation:
       type: object

--- a/specs/ws-api.yaml
+++ b/specs/ws-api.yaml
@@ -33,6 +33,12 @@ channels:
         $ref: '#/components/messages/SubscriptionUpdate'
       NewSolverOperation:
         $ref: '#/components/messages/NewSolverOperation'
+      OperationHash:
+        $ref: '#/components/messages/OperationHash'
+      GetSolverOperationStatus:
+        $ref: '#/components/messages/GetSolverOperationStatus'
+      SolverOperationStatusResponse:
+        $ref: '#/components/messages/SolverOperationStatusResponse'
   Bundler:
     address: /ws/bundler
     messages:
@@ -72,6 +78,7 @@ operations:
       - $ref: '#/channels/Solver/messages/Subscribe'
       - $ref: '#/channels/Solver/messages/Unsubscribe'
       - $ref: '#/channels/Solver/messages/NewSolverOperation'
+      - $ref: '#/channels/Solver/messages/GetSolverOperationStatus'
 
   sendSolverMessage:
     action: send
@@ -80,6 +87,8 @@ operations:
     messages:
       - $ref: '#/channels/Solver/messages/Success'
       - $ref: '#/channels/Solver/messages/Error'
+      - $ref: '#/channels/Solver/messages/OperationHash'
+      - $ref: '#/channels/Solver/messages/SolverOperationStatusResponse'
       - $ref: '#/channels/Solver/messages/SubscriptionUpdate'
   
   processBundlerMessage:
@@ -119,6 +128,16 @@ components:
         - payload:
             id: 2
             error: invalid topic
+    
+    OperationHash:
+      summary: Operation hash message
+      description: The operation hash message is sent in response to a successful request
+      payload:
+        $ref: '#/components/schemas/OperationHash'
+      examples:
+        - payload:
+            id: 1
+            operationHash: 0x6044c22ab257659b74b1eb4cf2f8f65e0bcc2d9fe832279efb42a6700873fa74
     
     Ping:
       summary: Ping server to determine whether a connection is alive
@@ -177,8 +196,24 @@ components:
         $ref: '#/components/schemas/NewSolverOperation'
       x-response:
         anyOf:
-          - $ref: '#/components/messages/Success'
+          - $ref: '#/components/messages/OperationHash'
           - $ref: '#/components/messages/Error'
+    
+    GetSolverOperationStatus:
+      summary: Request solver operation status
+      description: The client requests the status of a solver operation
+      payload:
+        $ref: '#/components/schemas/GetSolverOperationStatus'
+      x-response:
+        anyOf:
+          - $ref: '#/components/messages/SolverOperationStatusResponse'
+          - $ref: '#/components/messages/Error'
+    
+    SolverOperationStatusResponse:
+      summary: Solver operation status response
+      description: The server responds with the status of a solver operation
+      payload:
+        $ref: '#/components/schemas/SolverOperationStatusResponse'
     
     NewBundle:
       summary: The new bundle to be processed
@@ -193,6 +228,20 @@ components:
       summary: The generated Atlas transaction hash following a bundling request
       payload:
         $ref: '#/components/schemas/BundlingSuccess'
+
+
+
+
+
+
+
+
+
+
+
+
+
+
 
   schemas:
     ReqId:
@@ -222,6 +271,19 @@ components:
       required:
         - id
         - error
+  
+    OperationHash:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/ReqId'
+        result:
+          type: string
+          description: Solidity type bytes32
+          pattern: '^0x[0-9a-f]{64}$'
+      required:
+        - id
+        - result
 
     Ping:
       type: object
@@ -309,6 +371,37 @@ components:
         - id
         - method
         - params
+    
+    GetSolverOperationStatus:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/ReqId'
+        method:
+          type: string
+          const: solverOperationStatus
+        params:
+          type: object
+          properties:
+            operationHash:
+              type: string
+              description: Solidity type bytes32
+              pattern: '^0x[0-9a-f]{64}$'
+      required:
+        - id
+        - method
+        - params
+    
+    SolverOperationStatusResponse:
+      type: object
+      properties:
+        id:
+          $ref: '#/components/schemas/ReqId'
+        result:
+          $ref: '#/components/schemas/SolverOperationStatus'
+      required:
+        - id
+        - result
 
     NewBundle:
       type: object
@@ -477,6 +570,21 @@ components:
       type: array
       items:
         $ref: '#/components/schemas/SolverOperation'
+    
+    SolverOperationStatus:
+      type: object
+      properties:
+        code:
+          type: integer
+          description: "The status code for the solver operation (0: failure, 1: success, 2: pending)"
+          enum: [0, 1, 2]
+        message:
+          type: string
+          description: The status message for the solver operation
+          examples: ["included in auction", "auction is pending"]
+      required:
+        - code
+        - message
     
     DAppOperation:
       type: object

--- a/specs/ws-api.yaml
+++ b/specs/ws-api.yaml
@@ -229,20 +229,6 @@ components:
       payload:
         $ref: '#/components/schemas/BundlingSuccess'
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
   schemas:
     ReqId:
       type: integer

--- a/tests/auctioneer.go
+++ b/tests/auctioneer.go
@@ -121,8 +121,8 @@ func retreiveSolverOps(userOpHash common.Hash, wait bool) ([]*operation.SolverOp
 		Host:   "localhost:8080",
 		Path:   "/solverOperations",
 		RawQuery: url.Values{
-			"userOpHash": []string{userOpHash.Hex()},
-			"wait":       []string{fmt.Sprintf("%t", wait)},
+			"operationHash": []string{userOpHash.Hex()},
+			"wait":          []string{fmt.Sprintf("%t", wait)},
 		}.Encode(),
 	}
 
@@ -192,8 +192,8 @@ func retrieveAtlasTxHash(userOpHash common.Hash, wait bool) (common.Hash, error)
 		Host:   "localhost:8080",
 		Path:   "/bundleHash",
 		RawQuery: url.Values{
-			"userOpHash": []string{userOpHash.Hex()},
-			"wait":       []string{fmt.Sprintf("%t", wait)},
+			"operationHash": []string{userOpHash.Hex()},
+			"wait":          []string{fmt.Sprintf("%t", wait)},
 		}.Encode(),
 	}
 


### PR DESCRIPTION
Major changes of this PR:

1. SolverOps simulations are moved at the end of the auction. When an auction reaches its deadline, only 10 (configurable) solverOps will be selected by their highest scores, and simulated. Passing operations are added to the final list of solverOps, that can be retrieved by the `(GET)solverOperations` endpoint.

2. SolverOps submission and status. Considering the above change, solvers can't submit their operations and hold the request until having a final answer (ie. until the auction closes). The submission process has been changed to a submit/retrieve schema. The new solver submission flow is as follow:

For http submissions:
- Submit operation through `(POST)solverOperation` endpoint. Relay will make basic validations, ensure the balance of bonded atlEth is sufficient, and calculate the operation score. Returns the solverOpHash in case of success, or an error.
- Retrieve the operation status through `(GET)solverOperationStatus` endpoint. Returns the status of a particular solverOp by its hash. As for other retrieve endpoints, the `wait` parameter is available to hold the request until the completion of the auction.

For websocket submissions:
- Submit operation through the `submitSolverOperation` method. Reply with the solverOpHash or an error.
- Retrieve the operation status with the `solverOperationStatus` method.

Future possible improvements:
- Integrate new unit tests
- New solver websocket subscription topic `operationStatus` that would publish an update every time a solver operation status is changed