### PR TITLE
Compute altUserOpHash if flag is enable by the dApp

### DIFF
--- a/core/api.go
+++ b/core/api.go
@@ -9,9 +9,9 @@ import (
 	"time"
 
 	"github.com/FastLane-Labs/atlas-operations-relay/bundle"
-	relayCrypto "github.com/FastLane-Labs/atlas-operations-relay/crypto"
 	"github.com/FastLane-Labs/atlas-operations-relay/operation"
 	"github.com/FastLane-Labs/atlas-operations-relay/relayerror"
+	"github.com/FastLane-Labs/atlas-operations-relay/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
 	"github.com/go-playground/validator/v10"
@@ -264,7 +264,7 @@ func (api *Api) WebsocketBundler(w http.ResponseWriter, r *http.Request) {
 
 	// Validate the signature
 	signatureContent := fmt.Sprintf("%s:%d", bundler, timestamp)
-	signer, err := relayCrypto.RecoverEthereumSigner(signatureContent, signature)
+	signer, err := utils.RecoverEthereumSigner(signatureContent, signature)
 	if err != nil {
 		w.WriteHeader(http.StatusBadRequest)
 		w.Write(ErrBadSignature.Marshal())

--- a/core/onchain.go
+++ b/core/onchain.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/FastLane-Labs/atlas-operations-relay/contract/dAppControl"
 	"github.com/FastLane-Labs/atlas-operations-relay/log"
+	"github.com/FastLane-Labs/atlas-operations-relay/operation"
 	"github.com/FastLane-Labs/atlas-operations-relay/relayerror"
 	"github.com/ethereum/go-ethereum/common"
 )
@@ -57,4 +58,20 @@ func (r *Relay) getDAppSignatories(dAppControl common.Address) ([]common.Address
 	}
 
 	return signatories, nil
+}
+
+func (r *Relay) getDAppConfig(dAppControlAddress common.Address, userOp *operation.UserOperation) (*dAppControl.DAppConfig, *relayerror.Error) {
+	dAppControlContract, err := dAppControl.NewDAppControl(dAppControlAddress, r.ethClient)
+	if err != nil {
+		log.Info("failed to instantiate dapp control contract", "err", err)
+		return nil, relayerror.ErrServerInternal
+	}
+
+	dAppConfig, err := dAppControlContract.GetDAppConfig(nil, dAppControl.UserOperation(*userOp))
+	if err != nil {
+		log.Info("failed to get dapp config", "err", err)
+		return nil, relayerror.ErrServerInternal
+	}
+
+	return &dAppConfig, nil
 }

--- a/operation/bundle.go
+++ b/operation/bundle.go
@@ -58,22 +58,10 @@ func (b *BundleOperations) EncodeToRaw() *BundleOperationsRaw {
 	}
 }
 
-func (b *BundleOperations) Validate(ethClient *ethclient.Client, userOpHash common.Hash, atlas common.Address, atlasDomainSeparator common.Hash, userOpGasLimit *big.Int, dAppOpGasLimit *big.Int) *relayerror.Error {
+func (b *BundleOperations) Validate(ethClient *ethclient.Client, userOpHash common.Hash, atlas common.Address, atlasDomainSeparator common.Hash, userOpGasLimit *big.Int, dAppOpGasLimit *big.Int, dAppConfig *dAppControl.DAppConfig) *relayerror.Error {
 	// Re-validate user operation
 	if relayErr := b.UserOperation.Validate(ethClient, atlas, atlasDomainSeparator, userOpGasLimit); relayErr != nil {
 		return relayErr
-	}
-
-	dAppControlContract, err := dAppControl.NewDAppControl(b.DAppOperation.Control, ethClient)
-	if err != nil {
-		log.Info("failed to instantiate dapp control contract", "err", err)
-		return relayerror.ErrServerInternal
-	}
-
-	dAppConfig, err := dAppControlContract.GetDAppConfig(nil, dAppControl.UserOperation(*b.UserOperation))
-	if err != nil {
-		log.Info("failed to get dapp config", "err", err)
-		return relayerror.ErrServerInternal
 	}
 
 	callChainHash, err := b.CallChainHash(dAppConfig.CallConfig, dAppConfig.To)

--- a/operation/bundle.go
+++ b/operation/bundle.go
@@ -7,6 +7,7 @@ import (
 	"github.com/FastLane-Labs/atlas-operations-relay/contract/dAppControl"
 	"github.com/FastLane-Labs/atlas-operations-relay/log"
 	"github.com/FastLane-Labs/atlas-operations-relay/relayerror"
+	"github.com/FastLane-Labs/atlas-operations-relay/utils"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/math"
 	"github.com/ethereum/go-ethereum/crypto"
@@ -92,8 +93,7 @@ func (b *BundleOperations) CallChainHash(callConfig uint32, dAppControl common.A
 	counter := big.NewInt(0)
 	var callSequenceHash common.Hash
 
-	if callConfig&4 != 0 {
-		// Require preOps
+	if utils.FlagRequirePreOps(callConfig) {
 		preOpsEncoded, err := contract.DappControlAbi.Pack("preOpsCall", b.UserOperation)
 		if err != nil {
 			return common.Hash{}, err

--- a/operation/dApp.go
+++ b/operation/dApp.go
@@ -95,8 +95,7 @@ type DAppOperation struct {
 	Signature     []byte
 }
 
-func GenerateSimulationDAppOperation(userOp *UserOperation) *DAppOperation {
-	userOpHash, _ := userOp.Hash()
+func GenerateSimulationDAppOperation(userOpHash common.Hash, userOp *UserOperation) *DAppOperation {
 	return &DAppOperation{
 		From:          common.HexToAddress("0x0"),
 		To:            common.HexToAddress("0x0"),

--- a/operation/dApp.go
+++ b/operation/dApp.go
@@ -3,9 +3,9 @@ package operation
 import (
 	"math/big"
 
-	relayCrypto "github.com/FastLane-Labs/atlas-operations-relay/crypto"
 	"github.com/FastLane-Labs/atlas-operations-relay/log"
 	"github.com/FastLane-Labs/atlas-operations-relay/relayerror"
+	"github.com/FastLane-Labs/atlas-operations-relay/utils"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -211,7 +211,7 @@ func (d *DAppOperation) checkSignature(domainSeparator common.Hash) *relayerror.
 		return ErrDAppOpComputeProofHash.AddError(err)
 	}
 
-	signer, err := relayCrypto.RecoverEip712Signer(domainSeparator, proofHash, d.Signature)
+	signer, err := utils.RecoverEip712Signer(domainSeparator, proofHash, d.Signature)
 	if err != nil {
 		log.Info("failed to recover dApp public key", "err", err)
 		return ErrDappOpSignatureInvalid.AddError(err)

--- a/operation/solver.go
+++ b/operation/solver.go
@@ -3,9 +3,9 @@ package operation
 import (
 	"math/big"
 
-	relayCrypto "github.com/FastLane-Labs/atlas-operations-relay/crypto"
 	"github.com/FastLane-Labs/atlas-operations-relay/log"
 	"github.com/FastLane-Labs/atlas-operations-relay/relayerror"
+	"github.com/FastLane-Labs/atlas-operations-relay/utils"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -249,7 +249,7 @@ func (s *SolverOperation) checkSignature(domainSeparator common.Hash) *relayerro
 		return ErrSolverOpComputeProofHash.AddError(err)
 	}
 
-	signer, err := relayCrypto.RecoverEip712Signer(domainSeparator, proofHash, s.Signature)
+	signer, err := utils.RecoverEip712Signer(domainSeparator, proofHash, s.Signature)
 	if err != nil {
 		log.Info("failed to recover solver public key", "err", err)
 		return ErrSolverOpSignatureInvalid.AddError(err)

--- a/operation/user.go
+++ b/operation/user.go
@@ -5,9 +5,9 @@ import (
 	"math/big"
 	"math/rand"
 
-	relayCrypto "github.com/FastLane-Labs/atlas-operations-relay/crypto"
 	"github.com/FastLane-Labs/atlas-operations-relay/log"
 	"github.com/FastLane-Labs/atlas-operations-relay/relayerror"
+	"github.com/FastLane-Labs/atlas-operations-relay/utils"
 	"github.com/ethereum/go-ethereum/accounts/abi"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/common/hexutil"
@@ -234,7 +234,7 @@ func (u *UserOperation) checkSignature(domainSeparator common.Hash) *relayerror.
 		return ErrUserOpComputeProofHash.AddError(err)
 	}
 
-	signer, err := relayCrypto.RecoverEip712Signer(domainSeparator, proofHash, u.Signature)
+	signer, err := utils.RecoverEip712Signer(domainSeparator, proofHash, u.Signature)
 	if err != nil {
 		log.Info("failed to recover user public key", "err", err)
 		return ErrUserOpSignatureInvalid.AddError(err)

--- a/operation/user_test.go
+++ b/operation/user_test.go
@@ -30,7 +30,23 @@ func TestUserOperationHash(t *testing.T) {
 	userOp := generateUserOperation()
 	want := common.HexToHash("0x0e658352ea19af267ebd61688d3056cb0e432713bf4adde58dac46419eb25485")
 
-	result, err := userOp.Hash()
+	result, err := userOp.Hash(false)
+	if err != nil {
+		t.Errorf("UserOperation.Hash() error = %v", err)
+	}
+
+	if result != want {
+		t.Errorf("UserOperation.Hash() = %v, want %v", result, want)
+	}
+}
+
+func TestUserOperationAltHash(t *testing.T) {
+	t.Parallel()
+
+	userOp := generateUserOperation()
+	want := common.HexToHash("0xb715f6dca6a71f65387c6837476bf0ed9f9169a2b93fefed67d2fa82a8e1e1dc")
+
+	result, err := userOp.Hash(true)
 	if err != nil {
 		t.Errorf("UserOperation.Hash() error = %v", err)
 	}

--- a/tests/auctioneer.go
+++ b/tests/auctioneer.go
@@ -73,7 +73,7 @@ func newDemoUserOperation() *operation.UserOperation {
 }
 
 func sendUserRequest(userOp *operation.UserOperation) error {
-	userOpHash, relayErr := userOp.Hash()
+	userOpHash, relayErr := userOp.Hash(false)
 	if relayErr != nil {
 		return relayErr
 	}
@@ -180,7 +180,7 @@ func sendBundleOperation(userOp *operation.UserOperation, solverOps []*operation
 		return fmt.Errorf("expected status code 200, got %d: %s", resp.StatusCode, string(bodyBytes))
 	}
 
-	userOpHash, _ := userOp.Hash()
+	userOpHash, _ := userOp.Hash(false)
 	log.Info("relay sent bundleOps", "userOpHash", userOpHash.Hex(), "nSolverOps", len(bundleOps.SolverOperations))
 
 	return nil

--- a/tests/dApp.go
+++ b/tests/dApp.go
@@ -8,7 +8,7 @@ import (
 )
 
 func newDappOperation(userOp *operation.UserOperation, solverOps []*operation.SolverOperation) *operation.DAppOperation {
-	userOpHash, _ := userOp.Hash()
+	userOpHash, _ := userOp.Hash(false)
 
 	dAppControlContract, err := dAppControl.NewDAppControl(userOp.Control, ethClient)
 	if err != nil {

--- a/tests/error_handling_test.go
+++ b/tests/error_handling_test.go
@@ -81,7 +81,7 @@ func badSolverOpTest(t *testing.T, solveUserOpFunc solveUserOpFunc) {
 		t.Fatal(err)
 	}
 
-	userOpHash, _ := userOp.Hash()
+	userOpHash, _ := userOp.Hash(false)
 	solverOps, err := retreiveSolverOps(userOpHash, true)
 	if err != nil {
 		t.Fatal(err)

--- a/tests/integration_test.go
+++ b/tests/integration_test.go
@@ -54,7 +54,7 @@ func TestIntegration(t *testing.T) {
 	}
 
 	//user requests solver solutions
-	userOpHash, _ := userOp.Hash()
+	userOpHash, _ := userOp.Hash(false)
 	solverOps, err := retreiveSolverOps(userOpHash, true)
 	if err != nil {
 		t.Fatal(err)
@@ -113,7 +113,7 @@ func TestSolverHttp(t *testing.T) {
 	}
 
 	//user requests solver solutions
-	userOpHash, _ := userOp.Hash()
+	userOpHash, _ := userOp.Hash(false)
 	solverOps, err := retreiveSolverOps(userOpHash, true)
 	if err != nil {
 		t.Fatal(err)

--- a/utils/callconfig.go
+++ b/utils/callconfig.go
@@ -1,0 +1,104 @@
+package utils
+
+const (
+	indexUserNoncesSequenced = uint32(iota)
+	indexDAppNoncesSequenced
+	indexRequirePreOps
+	indexTrackPreOpsReturnData
+	indexTrackUserReturnData
+	indexDelegateUser
+	indexPreSolver
+	indexPostSolver
+	indexPostOpsCall
+	indexZeroSolvers
+	indexReuseUserOp
+	indexUserAuctioneer
+	indexSolverAuctioneer
+	indexUnknownAuctioneer
+	indexVerifyCallChainHash
+	indexForwardReturnData
+	indexNeedsFulfillment
+	indexTrustedOpHash
+	indexInvertBidValue
+	indexExPostBids
+)
+
+func FlagUserNoncesSequenced(callConfig uint32) bool {
+	return callConfig&(1<<indexUserNoncesSequenced) != 0
+}
+
+func FlagDAppNoncesSequenced(callConfig uint32) bool {
+	return callConfig&(1<<indexDAppNoncesSequenced) != 0
+}
+
+func FlagRequirePreOps(callConfig uint32) bool {
+	return callConfig&(1<<indexRequirePreOps) != 0
+}
+
+func FlagTrackPreOpsReturnData(callConfig uint32) bool {
+	return callConfig&(1<<indexTrackPreOpsReturnData) != 0
+}
+
+func FlagTrackUserReturnData(callConfig uint32) bool {
+	return callConfig&(1<<indexTrackUserReturnData) != 0
+}
+
+func FlagDelegateUser(callConfig uint32) bool {
+	return callConfig&(1<<indexDelegateUser) != 0
+}
+
+func FlagPreSolver(callConfig uint32) bool {
+	return callConfig&(1<<indexPreSolver) != 0
+}
+
+func FlagPostSolver(callConfig uint32) bool {
+	return callConfig&(1<<indexPostSolver) != 0
+}
+
+func FlagPostOpsCall(callConfig uint32) bool {
+	return callConfig&(1<<indexPostOpsCall) != 0
+}
+
+func FlagZeroSolvers(callConfig uint32) bool {
+	return callConfig&(1<<indexZeroSolvers) != 0
+}
+
+func FlagReuseUserOp(callConfig uint32) bool {
+	return callConfig&(1<<indexReuseUserOp) != 0
+}
+
+func FlagUserAuctioneer(callConfig uint32) bool {
+	return callConfig&(1<<indexUserAuctioneer) != 0
+}
+
+func FlagSolverAuctioneer(callConfig uint32) bool {
+	return callConfig&(1<<indexSolverAuctioneer) != 0
+}
+
+func FlagUnknownAuctioneer(callConfig uint32) bool {
+	return callConfig&(1<<indexUnknownAuctioneer) != 0
+}
+
+func FlagVerifyCallChainHash(callConfig uint32) bool {
+	return callConfig&(1<<indexVerifyCallChainHash) != 0
+}
+
+func FlagForwardReturnData(callConfig uint32) bool {
+	return callConfig&(1<<indexForwardReturnData) != 0
+}
+
+func FlagNeedsFulfillment(callConfig uint32) bool {
+	return callConfig&(1<<indexNeedsFulfillment) != 0
+}
+
+func FlagTrustedOpHash(callConfig uint32) bool {
+	return callConfig&(1<<indexTrustedOpHash) != 0
+}
+
+func FlagInvertBidValue(callConfig uint32) bool {
+	return callConfig&(1<<indexInvertBidValue) != 0
+}
+
+func FlagExPostBids(callConfig uint32) bool {
+	return callConfig&(1<<indexExPostBids) != 0
+}

--- a/utils/callconfig_test.go
+++ b/utils/callconfig_test.go
@@ -1,0 +1,736 @@
+package utils
+
+import (
+	"testing"
+)
+
+func TestFlagUserNoncesSequenced(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "UserNoncesSequenced",
+			callConfig: 1 << indexUserNoncesSequenced,
+			want:       true,
+		},
+		{
+			name:       "UserNoncesSequencedNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "UserNoncesSequencedAndDAppNoncesSequenced",
+			callConfig: 1<<indexUserNoncesSequenced | 1<<indexDAppNoncesSequenced,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagUserNoncesSequenced(tt.callConfig); got != tt.want {
+				t.Errorf("FlagUserNoncesSequenced() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagDAppNoncesSequenced(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "DAppNoncesSequenced",
+			callConfig: 1 << indexDAppNoncesSequenced,
+			want:       true,
+		},
+		{
+			name:       "DAppNoncesSequencedNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "DAppNoncesSequencedAndUserNoncesSequenced",
+			callConfig: 1<<indexDAppNoncesSequenced | 1<<indexUserNoncesSequenced,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagDAppNoncesSequenced(tt.callConfig); got != tt.want {
+				t.Errorf("FlagDAppNoncesSequenced() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagRequirePreOps(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "RequirePreOps",
+			callConfig: 1 << indexRequirePreOps,
+			want:       true,
+		},
+		{
+			name:       "RequirePreOpsNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "RequirePreOpsAndTrackPreOpsReturnData",
+			callConfig: 1<<indexRequirePreOps | 1<<indexTrackPreOpsReturnData,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagRequirePreOps(tt.callConfig); got != tt.want {
+				t.Errorf("FlagRequirePreOps() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagTrackPreOpsReturnData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "TrackPreOpsReturnData",
+			callConfig: 1 << indexTrackPreOpsReturnData,
+			want:       true,
+		},
+		{
+			name:       "TrackPreOpsReturnDataNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "TrackPreOpsReturnDataAndTrackUserReturnData",
+			callConfig: 1<<indexTrackPreOpsReturnData | 1<<indexTrackUserReturnData,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagTrackPreOpsReturnData(tt.callConfig); got != tt.want {
+				t.Errorf("FlagTrackPreOpsReturnData() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagTrackUserReturnData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "TrackUserReturnData",
+			callConfig: 1 << indexTrackUserReturnData,
+			want:       true,
+		},
+		{
+			name:       "TrackUserReturnDataNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "TrackUserReturnDataAndDelegateUser",
+			callConfig: 1<<indexTrackUserReturnData | 1<<indexDelegateUser,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagTrackUserReturnData(tt.callConfig); got != tt.want {
+				t.Errorf("FlagTrackUserReturnData() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagDelegateUser(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "DelegateUser",
+			callConfig: 1 << indexDelegateUser,
+			want:       true,
+		},
+		{
+			name:       "DelegateUserNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "DelegateUserAndPreSolver",
+			callConfig: 1<<indexDelegateUser | 1<<indexPreSolver,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagDelegateUser(tt.callConfig); got != tt.want {
+				t.Errorf("FlagDelegateUser() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagPreSolver(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "PreSolver",
+			callConfig: 1 << indexPreSolver,
+			want:       true,
+		},
+		{
+			name:       "PreSolverNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "PreSolverAndPostSolver",
+			callConfig: 1<<indexPreSolver | 1<<indexPostSolver,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagPreSolver(tt.callConfig); got != tt.want {
+				t.Errorf("FlagPreSolver() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagPostSolver(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "PostSolver",
+			callConfig: 1 << indexPostSolver,
+			want:       true,
+		},
+		{
+			name:       "PostSolverNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "PostSolverAndPostOpsCall",
+			callConfig: 1<<indexPostSolver | 1<<indexPostOpsCall,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagPostSolver(tt.callConfig); got != tt.want {
+				t.Errorf("FlagPostSolver() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagPostOpsCall(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "PostOpsCall",
+			callConfig: 1 << indexPostOpsCall,
+			want:       true,
+		},
+		{
+			name:       "PostOpsCallNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "PostOpsCallAndZeroSolvers",
+			callConfig: 1<<indexPostOpsCall | 1<<indexZeroSolvers,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagPostOpsCall(tt.callConfig); got != tt.want {
+				t.Errorf("FlagPostOpsCall() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagZeroSolvers(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "ZeroSolvers",
+			callConfig: 1 << indexZeroSolvers,
+			want:       true,
+		},
+		{
+			name:       "ZeroSolversNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "ZeroSolversAndReuseUserOp",
+			callConfig: 1<<indexZeroSolvers | 1<<indexReuseUserOp,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagZeroSolvers(tt.callConfig); got != tt.want {
+				t.Errorf("FlagZeroSolvers() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagReuseUserOp(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "ReuseUserOp",
+			callConfig: 1 << indexReuseUserOp,
+			want:       true,
+		},
+		{
+			name:       "ReuseUserOpNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "ReuseUserOpAndUserAuctioneer",
+			callConfig: 1<<indexReuseUserOp | 1<<indexUserAuctioneer,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagReuseUserOp(tt.callConfig); got != tt.want {
+				t.Errorf("FlagReuseUserOp() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagUserAuctioneer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "UserAuctioneer",
+			callConfig: 1 << indexUserAuctioneer,
+			want:       true,
+		},
+		{
+			name:       "UserAuctioneerNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "UserAuctioneerAndSolverAuctioneer",
+			callConfig: 1<<indexUserAuctioneer | 1<<indexSolverAuctioneer,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagUserAuctioneer(tt.callConfig); got != tt.want {
+				t.Errorf("FlagUserAuctioneer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagSolverAuctioneer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "SolverAuctioneer",
+			callConfig: 1 << indexSolverAuctioneer,
+			want:       true,
+		},
+		{
+			name:       "SolverAuctioneerNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "SolverAuctioneerAndUnknownAuctioneer",
+			callConfig: 1<<indexSolverAuctioneer | 1<<indexUnknownAuctioneer,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagSolverAuctioneer(tt.callConfig); got != tt.want {
+				t.Errorf("FlagSolverAuctioneer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagUnknownAuctioneer(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "UnknownAuctioneer",
+			callConfig: 1 << indexUnknownAuctioneer,
+			want:       true,
+		},
+		{
+			name:       "UnknownAuctioneerNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "UnknownAuctioneerAndUserNoncesSequenced",
+			callConfig: 1<<indexUnknownAuctioneer | 1<<indexUserNoncesSequenced,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagUnknownAuctioneer(tt.callConfig); got != tt.want {
+				t.Errorf("FlagUnknownAuctioneer() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagVerifyCallChainHash(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "VerifyCallChainHash",
+			callConfig: 1 << indexVerifyCallChainHash,
+			want:       true,
+		},
+		{
+			name:       "VerifyCallChainHashNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "VerifyCallChainHashAndIndexInvertBidValue",
+			callConfig: 1<<indexVerifyCallChainHash | 1<<indexInvertBidValue,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagVerifyCallChainHash(tt.callConfig); got != tt.want {
+				t.Errorf("FlagVerifyCallChainHash() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagInvertBidValue(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "InvertBidValue",
+			callConfig: 1 << indexInvertBidValue,
+			want:       true,
+		},
+		{
+			name:       "InvertBidValueNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "InvertBidValueAndUserNoncesSequenced",
+			callConfig: 1<<indexInvertBidValue | 1<<indexUserNoncesSequenced,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagInvertBidValue(tt.callConfig); got != tt.want {
+				t.Errorf("FlagInvertBidValue() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagNeedsFulfillment(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "NeedsFulfillment",
+			callConfig: 1 << indexNeedsFulfillment,
+			want:       true,
+		},
+		{
+			name:       "NeedsFulfillmentNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "NeedsFulfillmentAndTrustedOpHash",
+			callConfig: 1<<indexNeedsFulfillment | 1<<indexTrustedOpHash,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagNeedsFulfillment(tt.callConfig); got != tt.want {
+				t.Errorf("FlagNeedsFulfillment() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagTrustedOpHash(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "TrustedOpHash",
+			callConfig: 1 << indexTrustedOpHash,
+			want:       true,
+		},
+		{
+			name:       "TrustedOpHashNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "TrustedOpHashAndFlagForwardReturnData",
+			callConfig: 1<<indexTrustedOpHash | 1<<indexForwardReturnData,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagTrustedOpHash(tt.callConfig); got != tt.want {
+				t.Errorf("FlagTrustedOpHash() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagForwardReturnData(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "ForwardReturnData",
+			callConfig: 1 << indexForwardReturnData,
+			want:       true,
+		},
+		{
+			name:       "ForwardReturnDataNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "ForwardReturnDataAndFlagNeedsFulfillment",
+			callConfig: 1<<indexForwardReturnData | 1<<indexNeedsFulfillment,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagForwardReturnData(tt.callConfig); got != tt.want {
+				t.Errorf("FlagForwardReturnData() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagExPostBids(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		callConfig uint32
+		want       bool
+	}{
+		{
+			name:       "ExPostBids",
+			callConfig: 1 << indexExPostBids,
+			want:       true,
+		},
+		{
+			name:       "ExPostBidsNotSet",
+			callConfig: 0,
+			want:       false,
+		},
+		{
+			name:       "ExPostBidsAndFlagTrustedOpHash",
+			callConfig: 1<<indexExPostBids | 1<<indexTrustedOpHash,
+			want:       true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := FlagExPostBids(tt.callConfig); got != tt.want {
+				t.Errorf("FlagExPostBids() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFlagVerifyCallChainHashAndInvertBidValue(t *testing.T) {
+	t.Parallel()
+
+	callConfig := uint32(1<<indexVerifyCallChainHash | 1<<indexInvertBidValue)
+	want := true
+
+	if got := FlagVerifyCallChainHash(callConfig); got != want {
+		t.Errorf("FlagVerifyCallChainHash() = %v, want %v", got, want)
+	}
+
+	want = true
+
+	if got := FlagInvertBidValue(callConfig); got != want {
+		t.Errorf("FlagInvertBidValue() = %v, want %v", got, want)
+	}
+}
+
+func TestFlagTrackUserReturnDataAndDelegateUser(t *testing.T) {
+	t.Parallel()
+
+	callConfig := uint32(1<<indexTrackUserReturnData | 1<<indexDelegateUser)
+	want := true
+
+	if got := FlagTrackUserReturnData(callConfig); got != want {
+		t.Errorf("FlagTrackUserReturnData() = %v, want %v", got, want)
+	}
+
+	want = true
+
+	if got := FlagDelegateUser(callConfig); got != want {
+		t.Errorf("FlagDelegateUser() = %v, want %v", got, want)
+	}
+}
+
+func TestFlagPreSolverAndPostSolver(t *testing.T) {
+	t.Parallel()
+
+	callConfig := uint32(1<<indexPreSolver | 1<<indexPostSolver)
+	want := true
+
+	if got := FlagPreSolver(callConfig); got != want {
+		t.Errorf("FlagPreSolver() = %v, want %v", got, want)
+	}
+
+	want = true
+
+	if got := FlagPostSolver(callConfig); got != want {
+		t.Errorf("FlagPostSolver() = %v, want %v", got, want)
+	}
+}

--- a/utils/signature.go
+++ b/utils/signature.go
@@ -1,4 +1,4 @@
-package crypto
+package utils
 
 import (
 	"github.com/FastLane-Labs/atlas-operations-relay/log"

--- a/utils/signature_test.go
+++ b/utils/signature_test.go
@@ -1,4 +1,4 @@
-package crypto
+package utils
 
 import (
 	"testing"


### PR DESCRIPTION
Computes the user operation hash in different manners, depending on the `trustedOpHash` flag set by the dAppControl.