### PR TITLE
Solver op status subscription

### DIFF
--- a/auction/manager.go
+++ b/auction/manager.go
@@ -35,7 +35,7 @@ type solverGasLimitFn func(common.Address) (uint32, *relayerror.Error)
 type balanceOfBondedFn func(common.Address) (*big.Int, *relayerror.Error)
 type reputationScoreFn func(account common.Address) int
 type getDAppConfigFn func(common.Address, *operation.UserOperation) (*dAppControl.DAppConfig, *relayerror.Error)
-type solverOpStatusUpdateFn func(common.Hash, *SolverStatus)
+type solverOpStatusUpdateFn func(common.Hash, *SolverStatus, bool)
 
 type Manager struct {
 	ethClient *ethclient.Client
@@ -229,7 +229,7 @@ func (am *Manager) GetSolverOperationStatus(solverOpHash common.Hash, completion
 	return auction.getSolverOpStatus(solverOpHash, completionChan)
 }
 
-func (am *Manager) AttachSolverOpStatusUpdateFn(fn func(common.Hash, *SolverStatus)) {
+func (am *Manager) AttachSolverOpStatusUpdateFn(fn func(common.Hash, *SolverStatus, bool)) {
 	am.solverOpStatusUpdateFn = fn
 }
 

--- a/core/relay.go
+++ b/core/relay.go
@@ -69,6 +69,7 @@ func NewRelay(ethClient *ethclient.Client, config *config.Config) *Relay {
 	r.auctionManager = auction.NewManager(ethClient, config, atlasDomainSeparator, r.solverGasLimit, r.balanceOfBonded, r.reputationScore, r.getDAppConfig)
 	r.bundleManager = bundle.NewManager(ethClient, config, atlasDomainSeparator, r.getDAppConfig)
 	r.server = NewServer(NewRouter(NewApi(r)), r.auctionManager.NewSolverOperation, r.auctionManager.GetSolverOperationStatus, r.getDAppSignatories)
+	r.auctionManager.AttachSolverOpStatusUpdateFn(r.server.BroadcastSolverOpStatusUpdate)
 
 	return r
 }

--- a/core/server.go
+++ b/core/server.go
@@ -40,7 +40,7 @@ const (
 
 	// Subscriptions topics
 	TopicNewUserOperations    = "newUserOperations"
-	TopicUpdateSolverOpStatus = "updateSolverOperationStatus"
+	TopicUpdateSolverOpStatus = "solverOperationStatusUpdates"
 
 	//TopicDelimiter
 	TopicDelimiter = "_"

--- a/specs/ws-api.yaml
+++ b/specs/ws-api.yaml
@@ -1,20 +1,18 @@
-asyncapi: '3.0.0'
+asyncapi: 3.0.0
 info:
   title: Atlas Operations Relay websocket API
-  description: |
-    The websocket API implementation for an Atlas Operations Relay, based on the AsyncAPI 3.0.0 specification..
-
+  description: >
+    The websocket API implementation for an Atlas Operations Relay, based on the
+    AsyncAPI 3.0.0 specification..
   contact:
     email: technical-support@fastlane.finance
   license:
     name: Apache 2.0
     url: http://www.apache.org/licenses/LICENSE-2.0.html
-  version: '1.0.0'
-
+  version: 1.0.0
   externalDocs:
     description: See an Atlas Operations Relay implementation example
     url: https://github.com/FastLane-Labs/atlas-operations-relay
-
 channels:
   Solver:
     address: /ws/solver
@@ -62,12 +60,13 @@ channels:
             address:
               type: string
               description: The address of the bundler
-              pattern: '^0x[0-9a-f]{40}$'
+              pattern: ^0x[0-9a-f]{40}$
             signature:
               type: string
-              description: The concatenated signature of the timestamp and address by the bundler
-              pattern: '^0x([0-9a-f][0-9a-f])*$'
-
+              description: >-
+                The concatenated signature of the timestamp and address by the
+                bundler
+              pattern: ^0x([0-9a-f][0-9a-f])*$
 operations:
   processSolverMessage:
     action: receive
@@ -79,7 +78,6 @@ operations:
       - $ref: '#/channels/Solver/messages/Unsubscribe'
       - $ref: '#/channels/Solver/messages/NewSolverOperation'
       - $ref: '#/channels/Solver/messages/GetSolverOperationStatus'
-
   sendSolverMessage:
     action: send
     channel:
@@ -90,7 +88,6 @@ operations:
       - $ref: '#/channels/Solver/messages/OperationHash'
       - $ref: '#/channels/Solver/messages/SolverOperationStatusResponse'
       - $ref: '#/channels/Solver/messages/SubscriptionUpdate'
-  
   processBundlerMessage:
     action: receive
     channel:
@@ -99,14 +96,12 @@ operations:
       - $ref: '#/channels/Bundler/messages/Ping'
       - $ref: '#/channels/Bundler/messages/BundlingSuccess'
       - $ref: '#/channels/Bundler/messages/Error'
-  
   sendBundlerMessage:
     action: send
     channel:
       $ref: '#/channels/Bundler'
     messages:
       - $ref: '#/channels/Bundler/messages/NewBundle'
-
 components:
   messages:
     Success:
@@ -118,7 +113,6 @@ components:
         - payload:
             id: 1
             result: success
-    
     Error:
       summary: Error message
       description: The error message is sent in response to a failed request
@@ -128,7 +122,6 @@ components:
         - payload:
             id: 2
             error: invalid topic
-    
     OperationHash:
       summary: Operation hash message
       description: The operation hash message is sent in response to a successful request
@@ -137,11 +130,13 @@ components:
       examples:
         - payload:
             id: 1
-            operationHash: 0x6044c22ab257659b74b1eb4cf2f8f65e0bcc2d9fe832279efb42a6700873fa74
-    
+            operationHash: 4.354351915428908e+76
     Ping:
       summary: Ping server to determine whether a connection is alive
-      description: Client can ping server to determine whether connection is alive, server responds with pong. This is an application level ping as opposed to default ping in websockets standard which is server initiated
+      description: >-
+        Client can ping server to determine whether connection is alive, server
+        responds with pong. This is an application level ping as opposed to
+        default ping in websockets standard which is server initiated
       payload:
         $ref: '#/components/schemas/Ping'
       examples:
@@ -152,7 +147,6 @@ components:
         anyOf:
           - $ref: '#/components/messages/Success'
           - $ref: '#/components/messages/Error'
-
     Subscribe:
       description: Subscribe to a topic
       payload:
@@ -163,11 +157,16 @@ components:
             method: subscribe
             params:
               topic: newUserOperations
+        - payload:
+            id: 1
+            method: subscribe
+            params:
+              topic: >-
+                solverOperationStatusUpdates_0x23a427742cda59f692ff1bae5ac313b864295ef8a5fbafe569fff543afbf4134
       x-response:
         anyOf:
           - $ref: '#/components/messages/Success'
           - $ref: '#/components/messages/Error'
-
     Unsubscribe:
       description: Unsubscribe from a topic
       payload:
@@ -182,13 +181,13 @@ components:
         anyOf:
           - $ref: '#/components/messages/Success'
           - $ref: '#/components/messages/Error'
-    
     SubscriptionUpdate:
       summary: Subscription update
-      description: The server sends a subscription update to the client when there is a new event on the subscribed topic
+      description: >-
+        The server sends a subscription update to the client when there is a new
+        event on the subscribed topic
       payload:
         $ref: '#/components/schemas/SubscriptionUpdate'
-
     NewSolverOperation:
       summary: New solver operation to be submitted
       description: The client submits a new solver operation to the server
@@ -198,7 +197,6 @@ components:
         anyOf:
           - $ref: '#/components/messages/OperationHash'
           - $ref: '#/components/messages/Error'
-    
     GetSolverOperationStatus:
       summary: Request solver operation status
       description: The client requests the status of a solver operation
@@ -208,13 +206,11 @@ components:
         anyOf:
           - $ref: '#/components/messages/SolverOperationStatusResponse'
           - $ref: '#/components/messages/Error'
-    
     SolverOperationStatusResponse:
       summary: Solver operation status response
       description: The server responds with the status of a solver operation
       payload:
         $ref: '#/components/schemas/SolverOperationStatusResponse'
-    
     NewBundle:
       summary: The new bundle to be processed
       payload:
@@ -223,17 +219,14 @@ components:
         anyOf:
           - $ref: '#/components/messages/BundlingSuccess'
           - $ref: '#/components/messages/Error'
-    
     BundlingSuccess:
       summary: The generated Atlas transaction hash following a bundling request
       payload:
         $ref: '#/components/schemas/BundlingSuccess'
-
   schemas:
     ReqId:
       type: integer
       description: Client originated ID reflected in response message
-    
     Success:
       type: object
       properties:
@@ -245,7 +238,6 @@ components:
       required:
         - id
         - result
-    
     Error:
       type: object
       properties:
@@ -257,7 +249,6 @@ components:
       required:
         - id
         - error
-  
     OperationHash:
       type: object
       properties:
@@ -266,11 +257,10 @@ components:
         result:
           type: string
           description: Solidity type bytes32
-          pattern: '^0x[0-9a-f]{64}$'
+          pattern: ^0x[0-9a-f]{64}$
       required:
         - id
         - result
-
     Ping:
       type: object
       properties:
@@ -282,7 +272,6 @@ components:
       required:
         - id
         - method
-
     Subscribe:
       type: object
       properties:
@@ -296,12 +285,15 @@ components:
           properties:
             topic:
               type: string
-              enum: ['newUserOperations']
+              pattern: >-
+                ^(newUserOperations|solverOperationStatusUpdates_[a-fA-F0-9]{65})$
+              description: >-
+                Topic to subscribe to. This can be one of `newUserOperations` or
+                `updateSolverOperationStatus_0x<65-character hex_hash>`
       required:
         - id
         - method
         - params
-
     Unsubscribe:
       type: object
       properties:
@@ -315,12 +307,15 @@ components:
           properties:
             topic:
               type: string
-              enum: ['newUserOperations']
+              pattern: >-
+                ^(newUserOperations|solverOperationStatusUpdates_[a-fA-F0-9]{65})$
+              description: >-
+                Topic to subscribe to. This can be one of `newUserOperations` or
+                `updateSolverOperationStatus_0x<65-character hex_hash>`
       required:
         - id
         - method
         - params
-
     SubscriptionUpdate:
       type: object
       properties:
@@ -329,7 +324,8 @@ components:
           const: update
         topic:
           type: string
-          enum: ['newUserOperations']
+          enum:
+            - newUserOperations
         data:
           type: object
           properties:
@@ -339,7 +335,6 @@ components:
         - event
         - topic
         - data
-
     NewSolverOperation:
       type: object
       properties:
@@ -357,7 +352,6 @@ components:
         - id
         - method
         - params
-    
     GetSolverOperationStatus:
       type: object
       properties:
@@ -372,12 +366,11 @@ components:
             operationHash:
               type: string
               description: Solidity type bytes32
-              pattern: '^0x[0-9a-f]{64}$'
+              pattern: ^0x[0-9a-f]{64}$
       required:
         - id
         - method
         - params
-    
     SolverOperationStatusResponse:
       type: object
       properties:
@@ -388,7 +381,6 @@ components:
       required:
         - id
         - result
-
     NewBundle:
       type: object
       properties:
@@ -403,7 +395,6 @@ components:
         - id
         - event
         - bundle
-
     BundlingSuccess:
       type: object
       properties:
@@ -412,62 +403,62 @@ components:
         result:
           type: string
           description: The generated Atlas transaction hash
-          examples: ['0x6044c22ab257659b74b1eb4cf2f8f65e0bcc2d9fe832279efb42a6700873fa74']
+          examples:
+            - '0x6044c22ab257659b74b1eb4cf2f8f65e0bcc2d9fe832279efb42a6700873fa74'
       required:
         - id
         - result
-
     UserOperation:
       type: object
       properties:
         from:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         to:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         value:
           type: string
           description: Solidity type uint256
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         gas:
           type: string
           description: Solidity type uint256
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         maxFeePerGas:
           type: string
           description: Solidity type uint256
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         nonce:
           type: string
           description: Solidity type uint256
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         deadline:
           type: string
           description: Solidity type uint256
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         dapp:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         control:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         sessionKey:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         data:
           type: string
           description: Solidity type bytes
-          pattern: '^0x([0-9a-f][0-9a-f])*$'
+          pattern: ^0x([0-9a-f][0-9a-f])*$
         signature:
           type: string
           description: Solidity type bytes
-          pattern: '^0x([0-9a-f][0-9a-f])*$'
+          pattern: ^0x([0-9a-f][0-9a-f])*$
       required:
         - from
         - to
@@ -481,62 +472,61 @@ components:
         - sessionKey
         - data
         - signature
-    
     SolverOperation:
       type: object
       properties:
         from:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         to:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         value:
           type: string
           description: Solidity type uint256
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         gas:
           type: string
           description: Solidity type uint256
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         maxFeePerGas:
           type: string
           description: Solidity type uint256
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         deadline:
           type: string
           description: Solidity type uint256
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         solver:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         control:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         userOpHash:
           type: string
           description: Solidity type bytes32
-          pattern: '^0x[0-9a-f]{64}$'
+          pattern: ^0x[0-9a-f]{64}$
         bidToken:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         bidAmount:
           type: string
           description: Solidity type uint256
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         data:
           type: string
           description: Solidity type bytes
-          pattern: '^0x([0-9a-f][0-9a-f])*$'
+          pattern: ^0x([0-9a-f][0-9a-f])*$
         signature:
           type: string
           description: Solidity type bytes
-          pattern: '^0x([0-9a-f][0-9a-f])*$'
+          pattern: ^0x([0-9a-f][0-9a-f])*$
       required:
         - from
         - to
@@ -551,74 +541,78 @@ components:
         - bidAmount
         - data
         - signature
-    
     SolverOperations:
       type: array
       items:
         $ref: '#/components/schemas/SolverOperation'
-    
     SolverOperationStatus:
       type: object
       properties:
         code:
           type: integer
-          description: "The status code for the solver operation (0: failure, 1: success, 2: pending)"
-          enum: [0, 1, 2]
+          description: >-
+            The status code for the solver operation (0: failure, 1: success, 2:
+            pending)
+          enum:
+            - 0
+            - 1
+            - 2
         message:
           type: string
           description: The status message for the solver operation
-          examples: ["included in auction", "auction is pending"]
+          examples:
+            - included in auction
+            - auction is pending
       required:
         - code
         - message
-    
     DAppOperation:
       type: object
       properties:
         from:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         to:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         value:
           type: string
           description: Solidity type uint256
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         gas:
           type: string
           description: Solidity type uint256
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         nonce:
           type: string
           description: Solidity type uint256
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         deadline:
           type: string
           description: Solidity type uint256
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         control:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         bundler:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         userOpHash:
           type: string
           description: Solidity type bytes32
-          pattern: '^0x[0-9a-f]{64}$'
+          pattern: ^0x[0-9a-f]{64}$
         callChainHash:
           type: string
           description: Solidity type bytes32
-          pattern: '^0x[0-9a-f]{64}$'
+          pattern: ^0x[0-9a-f]{64}$
         signature:
           type: string
           description: Solidity type bytes
-          pattern: '^0x([0-9a-f][0-9a-f])*$'
+          pattern: ^0x([0-9a-f][0-9a-f])*$
       required:
         - from
         - to
@@ -631,7 +625,6 @@ components:
         - userOpHash
         - callChainHash
         - signature
-    
     Bundle:
       type: object
       properties:
@@ -645,57 +638,61 @@ components:
         - userOperation
         - solverOperations
         - dAppOperation
-    
     UserOperationPartial:
       type: object
       properties:
         userOpHash:
           type: string
           description: Solidity type bytes32
-          pattern: '^0x[0-9a-f]{64}$'
+          pattern: ^0x[0-9a-f]{64}$
         to:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         gas:
           type: string
           description: Solidity type uint256 represented in hex
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         maxFeePerGas:
           type: string
           description: Solidity type uint256 represented in hex
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         deadline:
           type: string
           description: Solidity type uint256 represented in hex
-          pattern: '^0x[0-9a-f]{1,64}$'
+          pattern: ^0x[0-9a-f]{1,64}$
         dapp:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         control:
           type: string
           description: Solidity type address
-          pattern: '^0x[0-9a-f]{40}$'
+          pattern: ^0x[0-9a-f]{40}$
         hints:
           type: array
           items:
             type: string
             description: Solidity type address
-            pattern: '^0x[0-9a-f]{40}$'
-          description: "An array of addresses used as hints for the operation. Exactly one of 'Hints' or the combination of 'Value', 'Data', 'From' must be set."
+            pattern: ^0x[0-9a-f]{40}$
+          description: >-
+            An array of addresses used as hints for the operation. Exactly one
+            of 'Hints' or the combination of 'Value', 'Data', 'From' must be
+            set.
         value:
           type: string
-          description: "Solidity type uint256 represented in hex. Required if 'Hints' is not set."
-          pattern: '^0x[0-9a-f]{1,64}$'
+          description: >-
+            Solidity type uint256 represented in hex. Required if 'Hints' is not
+            set.
+          pattern: ^0x[0-9a-f]{1,64}$
         data:
           type: string
-          description: "Solidity type bytes. Required if 'Hints' is not set."
-          pattern: '^0x([0-9a-f][0-9a-f])*$'
+          description: Solidity type bytes. Required if 'Hints' is not set.
+          pattern: ^0x([0-9a-f][0-9a-f])*$
         from:
           type: string
-          description: "Solidity type address. Required if 'Hints' is not set."
-          pattern: '^0x[0-9a-f]{40}$'
+          description: Solidity type address. Required if 'Hints' is not set.
+          pattern: ^0x[0-9a-f]{40}$
       required:
         - userOpHash
         - to


### PR DESCRIPTION
Adds a subscription type for solver op status. The topic is prescribed to be of the form `solverOperationStatusUpdates_<solver_op_hash>`. Relevant changes made in the specs ws-api.yaml